### PR TITLE
removing rxjs as direct dep

### DIFF
--- a/src/create-nteract-app.js
+++ b/src/create-nteract-app.js
@@ -107,7 +107,6 @@ function run(root, appName, version, verbose, originalDirectory, template) {
     "@nteract/editor",
     "@nteract/ion",
     "@nteract/logos",
-    "rxjs",
     "lodash"
   ];
 


### PR DESCRIPTION
This is included in the deps deps, so not necessary at the top level 🙂 