### PR TITLE
Add test to bootstrapped app

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
   "bin": {
     "create-nteract-app": "./src/index.js"
   },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "src/*",
+      "snow-leopard/*"
+    ]
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"

--- a/src/create-nteract-app.js
+++ b/src/create-nteract-app.js
@@ -191,6 +191,9 @@ function run(
       console.log(chalk.cyan(`  ${displayedCommand} dev`));
       console.log("    Starts the development server.");
       console.log();
+      console.log(chalk.cyan(`  ${displayedCommand} test`));
+      console.log("    Starts the test runner.");
+      console.log();
       console.log(chalk.cyan(`  ${displayedCommand} build`));
       console.log("    Builds the app for production.");
       console.log();

--- a/src/create-nteract-app.js
+++ b/src/create-nteract-app.js
@@ -75,7 +75,22 @@ function createApp(name, verbose, version, useNpm, template, language) {
       dev: "next",
       build: "next build",
       start: "next start",
-      export: "next export"
+      export: "next export",
+      test: "jest"
+    },
+    jest: {
+      setupFiles: ["./scripts/test-setup"]
+    },
+    devDependencies: {
+      "@babel/preset-env": "^7.0.0",
+      "@babel/preset-react": "^7.0.0",
+      "babel-core": "^7.0.0-0",
+      "@babel/core": "^7.0.0",
+      "babel-jest": "^23.4.2",
+      enzyme: "^3.6.0",
+      "enzyme-adapter-react-16": "^1.5.0",
+      "enzyme-to-json": "^3.3.4",
+      jest: "^23.5.0"
     }
   };
   fs.writeFileSync(

--- a/src/create-nteract-app.js
+++ b/src/create-nteract-app.js
@@ -99,15 +99,23 @@ function createApp(name, verbose, version, useNpm, template, language) {
   );
   const originalDirectory = process.cwd();
   process.chdir(root);
-  run(root, appName, version, verbose, originalDirectory, template);
+  const devDeps = Object.keys(packageJson.devDependencies);
+  run(root, appName, version, verbose, originalDirectory, template, devDeps);
 }
 const exec = require("child_process").exec;
 let nodePath;
 exec("npm config get prefix", function(err, stdout, stderr) {
   nodePath = stdout;
 });
-
-function run(root, appName, version, verbose, originalDirectory, template) {
+function run(
+  root,
+  appName,
+  version,
+  verbose,
+  originalDirectory,
+  template,
+  devDeps
+) {
   const allDependencies = [
     "react",
     "react-dom",
@@ -128,7 +136,10 @@ function run(root, appName, version, verbose, originalDirectory, template) {
   console.log("Installing packages. This might take a couple of minutes.");
   let packageName;
   console.log(
-    `Installing ${allDependencies.map(entry => chalk.cyan(entry)).join(", ")}`
+    `Installing ${allDependencies
+      .concat(devDeps)
+      .map(entry => chalk.cyan(entry))
+      .join(", ")}`
   );
   console.log();
   const useYarn = isYarnAvailable();

--- a/src/template/.babelrc
+++ b/src/template/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/src/template/.babelrc
+++ b/src/template/.babelrc
@@ -1,3 +1,13 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "env": {
+    "development": {
+      "presets": ["next/babel"]
+    },
+    "production": {
+      "presets": ["next/babel"]
+    },
+    "test": {
+      "presets": ["@babel/preset-env", "@babel/preset-react"]
+    }
+  }
 }

--- a/src/template/__tests__/index-spec.js
+++ b/src/template/__tests__/index-spec.js
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { shallow } from "enzyme";
+import toJson from "enzyme-to-json";
+
+import Index from "../pages";
+
+describe("test", () => {
+  it("renders the index page correctly", () => {
+    const component = shallow(<Index />);
+    expect(toJson(component)).toMatchSnapshot();
+  });
+});

--- a/src/template/scripts/test-setup.js
+++ b/src/template/scripts/test-setup.js
@@ -1,0 +1,4 @@
+const { configure } = require("enzyme");
+const Adapter = require("enzyme-adapter-react-16");
+
+configure({ adapter: new Adapter() });


### PR DESCRIPTION
Closes #21.

Adds Jest and a simple Jest snapshot test to the bootstrapped app to help the user get started with testing. 

This does bump up the number of dependencies -- too much I wonder 🤔?